### PR TITLE
Add support button to categories

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -891,6 +891,9 @@ async def show_categories(query: CallbackQuery):
     for cat in CACHED_CATEGORIES:
         kb.button(text=cat, callback_data=f"cat|{cat}|0")
     kb.adjust(2)
+    # добавляем кнопку поддержки в самый низ
+    kb.button(text="ПОДДЕРЖКА / СОТРУДНИЧЕСТВО❤️‍🔥", url="https://t.me/botmanager9")
+    kb.adjust(1)
 
     await query.message.edit_media(
         media=InputMediaPhoto(


### PR DESCRIPTION
## Summary
- add support/collaboration button after category buttons in `show_categories`

## Testing
- `python3 -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_684d34a975708325b50f53ece37a4a58